### PR TITLE
add pos (chaophraya hardfork) in genesis file

### DIFF
--- a/testnet/config.toml
+++ b/testnet/config.toml
@@ -14,12 +14,12 @@ TrieDirtyCache = 256
 TrieTimeout = 3600000000000
 SnapshotCache = 102
 EnablePreimageRecording = false
-RPCGasCap = 25000000
+RPCGasCap = 0
 RPCTxFeeCap = 1e+01
 
 [Eth.Miner]
-GasFloor = 30000000
-GasCeil = 30000000
+GasFloor = 65000000
+GasCeil = 65000000
 GasPrice = 5000000000
 Recommit = 3000000000
 Noverify = false

--- a/testnet/genesis.json
+++ b/testnet/genesis.json
@@ -12,11 +12,13 @@
       "istanbulBlock": 0,
       "erawanBlock": 3035353,
       "chaophrayaBlock": 11366422,
+      "chaophrayaBangkokBlock": 11730740,  
       "clique": {
 	"span": 50,
         "period": 5,
         "epoch": 30000,
-	"validatorContract": "0x724134567baaF90109947e12beB2c54FaD06287d"
+	"validatorContract": "0x724134567baaF90109947e12beB2c54FaD06287d",
+	"validatorContractV2": "0x5D9Fba8A40f876E76dB349731DeF0582135743C1"
       }
     },
     "nonce": "0x0",

--- a/testnet/genesis.json
+++ b/testnet/genesis.json
@@ -11,9 +11,12 @@
       "petersburgBlock": 0,
       "istanbulBlock": 0,
       "erawanBlock": 3035353,
+      "chaophrayaBlock": 11366422,
       "clique": {
+	"span": 50,
         "period": 5,
-        "epoch": 30000
+        "epoch": 30000,
+	"validatorContract": "0x724134567baaF90109947e12beB2c54FaD06287d"
       }
     },
     "nonce": "0x0",


### PR DESCRIPTION
Add the configurations to support the PoS consensus on Bitkub Chain (Chaophraya Hardfork).

What changes

- Add the chaophraya hardfork number for testnet.
- Add the bkcValidatorSet contract address.
- Change block gas limit 60,000,000 => 65,000,000.
