### PR TITLE
fect(mainnet): pos chaophraya hardfork

### DIFF
--- a/mainnet/config.toml
+++ b/mainnet/config.toml
@@ -13,12 +13,12 @@ TrieCleanCacheRejournal = 3600000000000
 TrieDirtyCache = 256
 TrieTimeout = 3600000000000
 EnablePreimageRecording = false
-RPCGasCap = 25000000
+RPCGasCap = 0
 RPCTxFeeCap = 1e+01
 
 [Eth.Miner]
-GasFloor = 60000000
-GasCeil = 60000000
+GasFloor = 65000000
+GasCeil = 65000000
 GasPrice = 5000000000
 Recommit = 3000000000
 Noverify = false

--- a/mainnet/genesis.json
+++ b/mainnet/genesis.json
@@ -11,9 +11,11 @@
     "petersburgBlock": 0,
     "istanbulBlock": 0,
     "erawanBlock": 5519559,
+    "chaophrayaBlock": 14220246,
     "clique": {
       "period": 5,
-      "epoch": 300
+      "epoch": 300,
+      "validatorContract": "0x61fAde2541dD13e855034346B4cA3576AB453FeC"
     }
   },
   "nonce": "0x0",


### PR DESCRIPTION
Add the configurations to support the PoS consensus on Bitkub Chain (Chaophraya Hardfork).

What changes

- Add the Chaophraya Hardfork number for mainnet.
- Add the BKCValidatorSet contract address.
- Change block gas limit 60,000,000 => 65,000,000.