### PR TITLE
Add Lausanne hard fork block on KUB Chain Testnet

### DIFF
--- a/testnet/genesis.json
+++ b/testnet/genesis.json
@@ -13,6 +13,7 @@
     "erawanBlock": 3035353,
     "chaophrayaBlock": 11366422,
     "chaophrayaBangkokBlock": 11730740,
+    "lausanneBlock": 22714084,
     "clique": {
       "span": 50,
       "period": 5,


### PR DESCRIPTION
Set the Lausanne hard fork block on KUB Chain Testnet as block number 22714084 (≈13 May 2025 16.00PM)